### PR TITLE
Enable override of userinfo URL

### DIFF
--- a/packages/switch_oidc/oidc_server.js
+++ b/packages/switch_oidc/oidc_server.js
@@ -86,7 +86,13 @@ var getToken = function (query) {
 var getUserInfo = function (accessToken) {
   var debug = false;
   var config = getConfiguration();
-  var serverUserinfoEndpoint = config.serverUrl + config.userinfoEndpoint;
+  // Some userinfo endpoints use a different base URL than the authorization or token endpoints.
+  // This logic allows the end user to override the setting by providing the full URL to userinfo in their config.
+  if config.userinfoEndpoint.includes("https://") {
+    var serverUserinfoEndpoint = config.userinfoEndpoint;
+  } else {
+    var serverUserinfoEndpoint = config.serverUrl + config.userinfoEndpoint;
+  }
   var response;
   try {
     response = HTTP.get(


### PR DESCRIPTION
Some userinfo endpoints use a different base URL than the authorization or token endpoints. This logic allows the end user to override the setting by providing the full URL to userinfo in their config.